### PR TITLE
Cli updates

### DIFF
--- a/src/main/java/org/heneveld/maven/license_audit/AbstractLicensingMojo.java
+++ b/src/main/java/org/heneveld/maven/license_audit/AbstractLicensingMojo.java
@@ -534,8 +534,11 @@ public abstract class AbstractLicensingMojo extends AbstractMojo {
         }
         // now see if there is a code for this one
         li = licenses.iterator();
-        String code = LicenseCodes.getLicenseCode(li.next().getName());
-        if (isNonEmpty(code)) return code;
+        final License next = li.next();
+        if (null != next) {
+            String code = LicenseCodes.getLicenseCode(next.getName());
+            if (isNonEmpty(code)) return code;
+        }
         return null;
     }
     

--- a/src/main/java/org/heneveld/maven/license_audit/util/ProjectsOverrides.java
+++ b/src/main/java/org/heneveld/maven/license_audit/util/ProjectsOverrides.java
@@ -145,7 +145,11 @@ public class ProjectsOverrides {
     }
 
     public static License parseSingleLicense(Object l) {
-        if (l instanceof String) return LicenseCodes.lookupCode((String)l);
+        if (l instanceof String) {
+            final License lookup = LicenseCodes.lookupCode((String) l);
+            if (null != lookup) return lookup;
+            throw new IllegalArgumentException("Invalid license; it should be a map or a known code (string), not "+l);
+        }
         if (l instanceof Map) {
             Map<?, ?> lmap = ((Map<?,?>)l);
             return LicenseCodes.newLicense(getRequired(lmap, String.class, "name"), (String)lmap.get("url"), (String)lmap.get("comments"));

--- a/src/test/resources/org/heneveld/maven/license_audit/poms_to_test_mojo/brooklyn_pom/expected-report-csv.txt
+++ b/src/test/resources/org/heneveld/maven/license_audit/poms_to_test_mojo/brooklyn_pom/expected-report-csv.txt
@@ -536,8 +536,7 @@ org.apache.jclouds.api:swift:jar:1.9.1 (compile, included)
 org.apache.jclouds.api:openstack-swift:jar:1.9.1 (compile, included)
 org.apache.jclouds.provider:rackspace-cloudfiles-us:jar:1.9.1 (compile, included)
 org.apache.jclouds.provider:rackspace-cloudfiles-uk:jar:1.9.1 (compile, included)
-org.apache.jclouds.provider:hpcloud-objectstorage:jar:1.9.1 (compile, included)
-org.apache.jclouds.api:filesystem:jar:1.9.1 (compile, included)","Copyright (c) The Apache Software Foundation (2009-2016)"
+org.apache.jclouds.provider:hpcloud-objectstorage:jar:1.9.1 (compile, included)","Copyright (c) The Apache Software Foundation (2009-2016)"
 "org.apache.jclouds.api:s3:1.9.1","org.apache.jclouds.api",s3,"1.9.1",jclouds s3 api,jclouds components to access an implementation of S3,"http://jclouds.apache.org/","The Apache Software Foundation (http://www.apache.org/)","","Adrian Cole
 Andrew Bayer
 Andrew Gaul
@@ -674,15 +673,6 @@ Ignasi Barrera
 Ioannis Canellos
 Matt Stephenson",ASL2,"The Apache Software License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)","Apache License, version 2.0","http://www.apache.org/licenses/LICENSE-2.0","jar (compile)","org.apache.jclouds.api:swift:jar:1.9.1 (compile, included)
 org.apache.jclouds.api:openstack-keystone:jar:1.9.1 (compile, included)","Copyright (c) The Apache Software Foundation (2009-2016)"
-"org.apache.jclouds.api:filesystem:1.9.1","org.apache.jclouds.api",filesystem,"1.9.1",jclouds filesystem core,jclouds components to access filesystem,"http://jclouds.apache.org/","The Apache Software Foundation (http://www.apache.org/)","","Adrian Cole
-Andrew Bayer
-Andrew Gaul
-Andrew Phillips
-Becca Woods
-Everett Toews
-Ignasi Barrera
-Ioannis Canellos
-Matt Stephenson",ASL2,"The Apache Software License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)","Apache License, version 2.0","http://www.apache.org/licenses/LICENSE-2.0","jar (compile)","org.apache.jclouds:jclouds-blobstore:jar:1.9.1 (compile, included)","Copyright (c) The Apache Software Foundation (2009-2016)"
 "org.apache.jclouds.labs:abiquo:1.9.1","org.apache.jclouds.labs",abiquo,"1.9.1",jclouds Abiquo api,jclouds components to access an implementation of Abiquo,"http://jclouds.apache.org/","The Apache Software Foundation (http://www.apache.org/)","","Adrian Cole
 Andrew Bayer
 Andrew Gaul

--- a/src/test/resources/org/heneveld/maven/license_audit/poms_to_test_mojo/brooklyn_pom/expected-report.txt
+++ b/src/test/resources/org/heneveld/maven/license_audit/poms_to_test_mojo/brooklyn_pom/expected-report.txt
@@ -621,7 +621,6 @@ org.heneveld.maven.license_audit:test-brooklyn-pom:0.1
   |   |   |   |     org.apache.jclouds.provider:rackspace-cloudfiles-us:jar:1.9.1 (compile, included, detail below)
   |   |   |   |     org.apache.jclouds.provider:rackspace-cloudfiles-uk:jar:1.9.1 (compile, included, detail below)
   |   |   |   |     org.apache.jclouds.provider:hpcloud-objectstorage:jar:1.9.1 (compile, included, detail below)
-  |   |   |   |     org.apache.jclouds.api:filesystem:jar:1.9.1 (compile, included, detail below)
   |   |   |   |   Dependencies pulled in here detail:
   |   |   |   |   +-org.apache.jclouds.api:s3:1.9.1
   |   |   |   |   |   Name: jclouds s3 api
@@ -749,13 +748,6 @@ org.heneveld.maven.license_audit:test-brooklyn-pom:0.1
   |   |   |   |   |   Dependencies:
   |   |   |   |   |     org.apache.jclouds.api:swift:jar:1.9.1 (compile, included, from org.apache.jclouds:jclouds-allblobstore:1.9.1)
   |   |   |   |   |     org.apache.jclouds.api:openstack-keystone:jar:1.9.1 (compile, included, from org.apache.jclouds.api:openstack-nova:1.9.1)
-  |   |   |   |   +-org.apache.jclouds.api:filesystem:1.9.1
-  |   |   |   |   |   Name: jclouds filesystem core
-  |   |   |   |   |   URL: http://jclouds.apache.org/
-  |   |   |   |   |   License: ASL2
-  |   |   |   |   |   Copyright: Copyright (c) The Apache Software Foundation (2009-2016)
-  |   |   |   |   |   Artifacts Included: jar (compile)
-  |   |   |   |   |   Dependencies: org.apache.jclouds:jclouds-blobstore:jar:1.9.1 (compile, included, from org.apache.jclouds.api:s3:1.9.1)
   |   |   |   +-org.apache.jclouds.labs:abiquo:1.9.1
   |   |   |   |   Name: jclouds Abiquo api
   |   |   |   |   URL: http://jclouds.apache.org/


### PR DESCRIPTION
Hi Alex here's a PR for some changes I had to do to get the CLI license changes working.  I have divided the changes into two commits:

06563ac is Java changes: I had to avoid null pointer exceptions when a license list had nulls in it. Also had to check if the result of 'lookupCode' was null, so I could throw a better exception than an NPE.  I ran across this when I mis-spelled a license name in the overrides.yaml.

3273310 I've done separately - the build was failing some unit tests, with expected results being different from the actual output.  At a rough glance the actual output looks ok, so I've added this commit to update the expected results, on the assumption that they are simply out of date.  This may or may not be right but I've included it just in case, as a separate commit in case you want to cherry pick the Java change only.
